### PR TITLE
Update to use bootstrap_barrio's 5.5.x branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://drupal.org/project/bootstrap_sass",
     "license": "GPL-2.0+",
     "require": {
-        "drupal/bootstrap_barrio": "5.x-dev",
+        "drupal/bootstrap_barrio": "5.5.x-dev",
         "drupal/bootstrap_sass": "5.x-dev"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://drupal.org/project/bootstrap_sass",
     "license": "GPL-2.0+",
     "require": {
-        "drupal/bootstrap_barrio": "5.5.x-dev",
-        "drupal/bootstrap_sass": "5.x-dev"
+        "drupal/bootstrap_barrio": "^5",
+        "drupal/bootstrap_sass": "^5"
     }
 }


### PR DESCRIPTION
Bootstrap Barrio's [5.x branch](https://git.drupalcode.org/project/bootstrap_barrio/-/blob/5.x/bootstrap_barrio.info.yml) doesn't install anymore - it includes both the `core` and the `core_version_requirement` directives.

This has been fixed in the [5.5.x branch](https://git.drupalcode.org/project/bootstrap_barrio/-/blob/5.5.x/bootstrap_barrio.info.yml), which seems to be where the active dev is happening.